### PR TITLE
Add an unprivileged user and set root password

### DIFF
--- a/recipes-core/images/hawkeye-image-dev.bb
+++ b/recipes-core/images/hawkeye-image-dev.bb
@@ -9,6 +9,7 @@ DESCRIPTION = "A console-only base image for development"
 
 require hawkeye-image.bb
 
+HAWKEYE_ROOT_PASSWORD ?= ""
 IMAGE_FEATURES += "debug-tweaks"
 
 CORE_IMAGE_BASE_INSTALL += "packagegroup-hawkeye-dev"

--- a/recipes-core/images/hawkeye-image.bb
+++ b/recipes-core/images/hawkeye-image.bb
@@ -26,6 +26,25 @@ EXTRA_USERS_PARAMS += "\
     -p '$(openssl passwd -6 ${@ d.getVar('HAWKEYE_USER_PASSWORD')})' \
     ${@ d.getVar('HAWKEYE_USER')};"
 
+# Set a password for the 'root' user
+HAWKEYE_DEFAULT_ROOT_PASSWORD ?= "hawkeye"
+do_rootfs[prefuncs] += "set_root_password"
+python set_root_password() {
+    rootpw = d.getVar("HAWKEYE_ROOT_PASSWORD")
+    if rootpw is None:
+        bb.warn("Using default password for root user. ",
+                "You should set HAWKEYE_ROOT_PASSWORD to override.")
+        d.setVar("HAWKEYE_ROOT_PASSWORD", d.getVar("HAWKEYE_DEFAULT_ROOT_PASSWORD"))
+
+    # Do not update password if the variable is explicitly set as an empty string
+    elif rootpw.strip() == "":
+        bb.verbnote("Using empty password for root user.")
+        return
+
+    d.appendVar("EXTRA_USERS_PARAMS", "usermod -p '$(openssl passwd -6 %s)' root;"
+                % d.getVar("HAWKEYE_ROOT_PASSWORD"))
+}
+
 # Install self-signed certificate for mender server
 MENDER_SERVER_CERT ?= ""
 IMAGE_INSTALL_append = " ${@'mender-server-certificate' if (d.getVar('MENDER_SERVER_CERT') != '') else ''}"


### PR DESCRIPTION
This adds a new user `hawkeye` with a default password "`hawkeye`". Password can be configured via distro of `local.conf`.

The password for user `root` is given a default value ("`hawkeye`") for regular images and stays empty by default for `-dev` images. This pasword can be configured like the `hawkeye` user password. Failing to do so will produce a warning:
```
WARNING: hawkeye-image-1.0-r0 do_rootfs: Using default password for root user. You should set HAWKEYE_ROOT_PASSWORD to override.
```

Closes #4 