### PR TITLE
packagegroup-hawkeye: install Wireguard kernel module

### DIFF
--- a/recipes-hawkeye/packagegroups/packagegroup-hawkeye.bb
+++ b/recipes-hawkeye/packagegroups/packagegroup-hawkeye.bb
@@ -20,6 +20,7 @@ RDEPENDS_${PN}-base = " \
     haveged \
     procps \
     less \
+    kernel-module-wireguard \
     docker-ce \
     python3-docker-compose \
     data-overlay-setup \


### PR DESCRIPTION
Signed-off-by: Pelle van Gils <pelle@hwky.ai>